### PR TITLE
Update email address in seed migration for defaults table

### DIFF
--- a/src/migrations/20260205_203823_seed_defaults.ts
+++ b/src/migrations/20260205_203823_seed_defaults.ts
@@ -4,7 +4,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   // Insert parent first: defaults_socila_links_handlers has FK _parent_id -> defaults(id)
   await db.run(sql`
     INSERT INTO defaults (personal_details_name, personal_details_role, personal_details_location, personal_details_email, personal_details_phone, updated_at, created_at)
-    VALUES ('Stephen Goncalves', 'Software Engineer', 'Notthingham, UK', 'stephen@stephengoncalves.dev', '4407590775593', datetime('now'), datetime('now'));
+    VALUES ('Stephen Goncalves', 'Software Engineer', 'Notthingham, UK', 'stephengoncalves.dev@gmail.com', '4407590775593', datetime('now'), datetime('now'));
   `)
 
   await db.run(sql`


### PR DESCRIPTION
## Summary
Updates the seeded default email in the defaults migration so new installs get the correct contact address.
What changed

- File: src/migrations/20260205_203823_seed_defaults.ts
- Field: personal_details_email in the defaults table seed INSERT
- Before: stephen@stephengoncalves.dev
- After: stephengoncalves.dev@gmail.com

## Why
The migration seeds the defaults row (name, role, location, email, phone, etc.). The previous domain-style address was wrong or no longer used; the seed now matches the intended Gmail contact.

## Notes
Already migrated DBs: This only affects the up() seed SQL. Environments that already ran this migration will not be updated automatically—update personal_details_email in the CMS/DB manually if needed, or add a follow-up migration if you want to correct existing rows in code.